### PR TITLE
Fix/invalid variances

### DIFF
--- a/elevation_mapping/src/ElevationMap.cpp
+++ b/elevation_mapping/src/ElevationMap.cpp
@@ -261,19 +261,19 @@ bool ElevationMap::fuse(const grid_map::Index& topLeftIndex, const grid_map::Ind
     const float& sigmaYsquare = rawMapCopy.at("horizontal_variance_y", *areaIterator);
     const float& sigmaXYsquare = rawMapCopy.at("horizontal_variance_xy", *areaIterator);
 
-    // Validate variances
-    if (!std::isfinite(sigmaXsquare) || !std::isfinite(sigmaYsquare) || !std::isfinite(sigmaXYsquare)) {
-      ROS_ERROR("Invalid variances when fusing the map: sigmaXsquare = %f, sigmaYsquare = %f, sigmaXYsquare = %f",
-                sigmaXsquare, sigmaYsquare, sigmaXYsquare);
-      continue;
-    }
-
     Eigen::Matrix2d covarianceMatrix;
     covarianceMatrix << sigmaXsquare, sigmaXYsquare, sigmaXYsquare, sigmaYsquare;
     // 95.45% confidence ellipse which is 2.486-sigma for 2 dof problem.
     // http://www.reid.ai/2012/09/chi-squared-distribution-table-with.html
     const double uncertaintyFactor = 2.486; // sqrt(6.18)
     Eigen::EigenSolver<Eigen::Matrix2d> solver(covarianceMatrix);
+
+    // Validate whether the eigensolver did succeed
+    if (solver.info() == Eigen::NumericalIssue) {
+      ROS_ERROR_STREAM("EigenSolver NumericalIssue when fusing the map, covarianceMatrix: " << covarianceMatrix);
+      continue;
+    }
+
     Eigen::Array2d eigenvalues(solver.eigenvalues().real().cwiseAbs());
 
     Eigen::Array2d::Index maxEigenvalueIndex;

--- a/elevation_mapping/src/ElevationMap.cpp
+++ b/elevation_mapping/src/ElevationMap.cpp
@@ -261,6 +261,13 @@ bool ElevationMap::fuse(const grid_map::Index& topLeftIndex, const grid_map::Ind
     const float& sigmaYsquare = rawMapCopy.at("horizontal_variance_y", *areaIterator);
     const float& sigmaXYsquare = rawMapCopy.at("horizontal_variance_xy", *areaIterator);
 
+    // Validate variances
+    if (!std::isfinite(sigmaXsquare) || !std::isfinite(sigmaYsquare) || !std::isfinite(sigmaXYsquare)) {
+      ROS_ERROR("Invalid variances when fusing the map: sigmaXsquare = %f, sigmaYsquare = %f, sigmaXYsquare = %f",
+                sigmaXsquare, sigmaYsquare, sigmaXYsquare);
+      continue;
+    }
+
     Eigen::Matrix2d covarianceMatrix;
     covarianceMatrix << sigmaXsquare, sigmaXYsquare, sigmaXYsquare, sigmaYsquare;
     // 95.45% confidence ellipse which is 2.486-sigma for 2 dof problem.


### PR DESCRIPTION
Check whether the eigensolver can find a solution. https://eigen.tuxfamily.org/dox/EigenSolver_8h_source.html (line 348) raises an assertion otherwise. This happened when fusing a pose with a large covariance. Fixes #62