### PR TITLE
Removed mutex lock of visibilityCleanupMap

### DIFF
--- a/elevation_mapping/src/ElevationMap.cpp
+++ b/elevation_mapping/src/ElevationMap.cpp
@@ -374,13 +374,10 @@ bool ElevationMap::clear()
 {
   boost::recursive_mutex::scoped_lock scopedLockForRawData(rawMapMutex_);
   boost::recursive_mutex::scoped_lock scopedLockForFusedData(fusedMapMutex_);
-  boost::recursive_mutex::scoped_lock scopedLockForVisibilityCleanupData(visibilityCleanupMapMutex_);
   rawMap_.clearAll();
   rawMap_.resetTimestamp();
   fusedMap_.clearAll();
   fusedMap_.resetTimestamp();
-  visibilityCleanupMap_.clearAll();
-  visibilityCleanupMap_.resetTimestamp();
   return true;
 }
 


### PR DESCRIPTION
The clear_map service crashes when the visibility_cleanup_rate is high.
This is because it fails to lock the visibilityCleanupMapMutex_ at `ElevationMap::clear` function.
Since this mutex is used to lock visibilityCleanupMap_ and this is only used during the visibility clean up,
it is not needed to clear this map.
So, I removed the clearing from the `ElevationMap::clear` function.