### PR TITLE
Fix for issue #93

### DIFF
--- a/elevation_mapping/include/elevation_mapping/ElevationMapping.hpp
+++ b/elevation_mapping/include/elevation_mapping/ElevationMapping.hpp
@@ -258,7 +258,7 @@ class ElevationMapping
   boost::thread visibilityCleanupThread_;
 
   //! Becomes true when corresponding poses and point clouds can be found
-  bool initialized_; 
+  bool receivedFirstMatchingPointcloudAndPose_;
 };
 
 } /* namespace */

--- a/elevation_mapping/include/elevation_mapping/ElevationMapping.hpp
+++ b/elevation_mapping/include/elevation_mapping/ElevationMapping.hpp
@@ -256,6 +256,9 @@ class ElevationMapping
 
   //! Callback thread for raytracing cleanup.
   boost::thread visibilityCleanupThread_;
+
+  //! Becomes true when corresponding poses and point clouds can be found
+  bool initialized_; 
 };
 
 } /* namespace */

--- a/elevation_mapping/src/ElevationMapping.cpp
+++ b/elevation_mapping/src/ElevationMapping.cpp
@@ -247,7 +247,7 @@ void ElevationMapping::pointCloudCallback(
       ROS_WARN_THROTTLE(5, "No corresponding point cloud and pose are found. Waiting for first match.");
       return;
     } else {
-      ROS_WARN("First corresponding point cloud and pose found, initialized. ");
+      ROS_INFO("First corresponding point cloud and pose found, initialized. ");
       receivedFirstMatchingPointcloudAndPose_ = true;
     }
   }

--- a/elevation_mapping/src/ElevationMapping.cpp
+++ b/elevation_mapping/src/ElevationMapping.cpp
@@ -239,11 +239,11 @@ void ElevationMapping::pointCloudCallback(
     const sensor_msgs::PointCloud2& rawPointCloud)
 {
   // Check if point cloud has corresponding robot pose at the beginning
-  if(not receivedFirstMatchingPointcloudAndPose_) {
+  if(!receivedFirstMatchingPointcloudAndPose_) {
     const double oldestPoseTime = robotPoseCache_.getOldestTime().toSec();
-    const double currentPclTime = rawPointCloud.header.stamp.toSec();
+    const double currentPointCloudTime = rawPointCloud.header.stamp.toSec();
 
-    if(currentPclTime < oldestPoseTime) {
+    if(currentPointCloudTime < oldestPoseTime) {
       ROS_WARN_THROTTLE(5, "No corresponding point cloud and pose are found. Waiting for first match.");
       return;
     } else {
@@ -388,13 +388,13 @@ bool ElevationMapping::updatePrediction(const ros::Time& time)
   // Get robot pose at requested time.
   boost::shared_ptr<geometry_msgs::PoseWithCovarianceStamped const> poseMessage = robotPoseCache_.getElemBeforeTime(time);
   if (!poseMessage) {
-      // Tell the user that either for the timestamp no pose is available or that the buffer is possibly empty 
-      if(robotPoseCache_.getOldestTime().toSec() > lastPointCloudUpdateTime_.toSec()) {
-        ROS_ERROR("The oldest pose available is at %f, requested pose at %f", robotPoseCache_.getOldestTime().toSec(), lastPointCloudUpdateTime_.toSec());
-      } else {
-        ROS_ERROR("Could not get pose information from robot for time %f. Buffer empty?", lastPointCloudUpdateTime_.toSec());
-      }
-      return false;
+    // Tell the user that either for the timestamp no pose is available or that the buffer is possibly empty 
+    if(robotPoseCache_.getOldestTime().toSec() > lastPointCloudUpdateTime_.toSec()) {
+      ROS_ERROR("The oldest pose available is at %f, requested pose at %f", robotPoseCache_.getOldestTime().toSec(), lastPointCloudUpdateTime_.toSec());
+    } else {
+      ROS_ERROR("Could not get pose information from robot for time %f. Buffer empty?", lastPointCloudUpdateTime_.toSec());
+    }
+    return false;
   }
 
   HomTransformQuatD robotPose;


### PR DESCRIPTION
While the nodes start up, it can happen that a point cloud arrives that does not find a matching pose. This leads to an Error and confusion of the user. The system starts to work normally once a matching point cloud and pose is available.
An initializing functionality that waits for a matching pair of point cloud and pose is implemented with this commit.\
The user is indicated with a Warn message that initialization is not finished.
The original Error message has been extended for better readability.
Note: robotPoseCache_ does not have a function to check if it is empty.