### PR TITLE
remove trailing whitespace

### DIFF
--- a/elevation_mapping/src/ElevationMapping.cpp
+++ b/elevation_mapping/src/ElevationMapping.cpp
@@ -283,7 +283,7 @@ void ElevationMapping::pointCloudCallback(
   if (!ignoreRobotMotionUpdates_) {
     boost::shared_ptr<geometry_msgs::PoseWithCovarianceStamped const> poseMessage = robotPoseCache_.getElemBeforeTime(lastPointCloudUpdateTime_);
     if (!poseMessage) {
-      // Tell the user that either for the timestamp no pose is available or that the buffer is possibly empty 
+      // Tell the user that either for the timestamp no pose is available or that the buffer is possibly empty
       if(robotPoseCache_.getOldestTime().toSec() > lastPointCloudUpdateTime_.toSec()) {
         ROS_ERROR("The oldest pose available is at %f, requested pose at %f", robotPoseCache_.getOldestTime().toSec(), lastPointCloudUpdateTime_.toSec());
       } else {
@@ -388,7 +388,7 @@ bool ElevationMapping::updatePrediction(const ros::Time& time)
   // Get robot pose at requested time.
   boost::shared_ptr<geometry_msgs::PoseWithCovarianceStamped const> poseMessage = robotPoseCache_.getElemBeforeTime(time);
   if (!poseMessage) {
-    // Tell the user that either for the timestamp no pose is available or that the buffer is possibly empty 
+    // Tell the user that either for the timestamp no pose is available or that the buffer is possibly empty
     if(robotPoseCache_.getOldestTime().toSec() > lastPointCloudUpdateTime_.toSec()) {
       ROS_ERROR("The oldest pose available is at %f, requested pose at %f", robotPoseCache_.getOldestTime().toSec(), lastPointCloudUpdateTime_.toSec());
     } else {


### PR DESCRIPTION
Remove trailing whitespace from all cpp, hpp, and tpp files. Some editors automatically handle this and create false diffs.

A quick oneliner in bash can do this for any files of a specified file extension in a given directory:
`find ./ -name "*.hpp" -or -name "*.cpp" -or -name "*.tpp" | xargs -o sed -i 's/[[:space:]]*$//'`