### PR TITLE
Add optional voxelgrid filter and new service to request raw sub map

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,15 @@ This is the main Robot-Centric Elevation Mapping node. It uses the distance sens
 
 * **`get_submap`** ([grid_map_msg/GetGridMap])
 
-    Get a fused elevation submap for a requested position and size. For example, you can get the fused elevation submap at position (-0.5, 0.0) and size (0.5, 1.2) and safe it to a text file form the console with
+    Get a fused elevation submap for a requested position and size. For example, you can get the fused elevation submap at position (-0.5, 0.0) and size (0.5, 1.2) described in the odom frame and safe it to a text file form the console with
 
-        rosservice call -- /elevation_mapping/get_submap -0.5 0.0 0.5 1.2 []
+        rosservice call -- /elevation_mapping/get_submap odom -0.5 0.0 0.5 1.2 []
+
+* **`get_submap`** ([grid_map_msg/GetGridMap])
+
+    Get a raw elevation submap for a requested position and size. For example, you can get the raw elevation submap at position (-0.5, 0.0) and size (0.5, 1.2) described in the odom frame and safe it to a text file form the console with
+
+        rosservice call -- /elevation_mapping/get_raw_submap odom -0.5 0.0 0.5 1.2 []
 
 * **`clear_map`** ([std_srvs/Empty])
 

--- a/elevation_mapping/include/elevation_mapping/ElevationMapping.hpp
+++ b/elevation_mapping/include/elevation_mapping/ElevationMapping.hpp
@@ -98,12 +98,12 @@ class ElevationMapping
   bool fuseEntireMap(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 
   /*!
-   * ROS service callback function to return a submap of the elevation map.
+   * ROS service callback function to return a submap of the fused elevation map.
    * @param request the ROS service request defining the location and size of the submap.
    * @param response the ROS service response containing the requested submap.
    * @return true if successful.
    */
-  bool getSubmap(grid_map_msgs::GetGridMap::Request& request, grid_map_msgs::GetGridMap::Response& response);
+  bool getFusedSubmap(grid_map_msgs::GetGridMap::Request& request, grid_map_msgs::GetGridMap::Response& response);
 
   /*!
    * ROS service callback function to return a submap of the raw elevation map.
@@ -192,7 +192,7 @@ class ElevationMapping
 
   //! ROS service servers.
   ros::ServiceServer fusionTriggerService_;
-  ros::ServiceServer submapService_;
+  ros::ServiceServer fusedSubmapService_;
   ros::ServiceServer rawSubmapService_;
   ros::ServiceServer clearMapService_;
   ros::ServiceServer saveMapService_;

--- a/elevation_mapping/include/elevation_mapping/ElevationMapping.hpp
+++ b/elevation_mapping/include/elevation_mapping/ElevationMapping.hpp
@@ -99,8 +99,8 @@ class ElevationMapping
 
   /*!
    * ROS service callback function to return a submap of the fused elevation map.
-   * @param request the ROS service request defining the location and size of the submap.
-   * @param response the ROS service response containing the requested submap.
+   * @param request the ROS service request defining the location and size of the fused submap.
+   * @param response the ROS service response containing the requested fused submap.
    * @return true if successful.
    */
   bool getFusedSubmap(grid_map_msgs::GetGridMap::Request& request, grid_map_msgs::GetGridMap::Response& response);

--- a/elevation_mapping/include/elevation_mapping/sensor_processors/LaserSensorProcessor.hpp
+++ b/elevation_mapping/include/elevation_mapping/sensor_processors/LaserSensorProcessor.hpp
@@ -46,7 +46,7 @@ private:
 	 * @param pointCloud the point cloud to clean.
 	 * @return true if successful.
 	 */
-	virtual bool cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
+	virtual bool cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
 
   /*!
    * Computes the elevation map height variances for each point in a point cloud with the

--- a/elevation_mapping/include/elevation_mapping/sensor_processors/PerfectSensorProcessor.hpp
+++ b/elevation_mapping/include/elevation_mapping/sensor_processors/PerfectSensorProcessor.hpp
@@ -46,7 +46,7 @@ private:
    * @param pointCloud the point cloud to clean.
    * @return true if successful.
    */
-  virtual bool cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
+  virtual bool cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
 
   /*!
    * Computes the elevation map height variances for each point in a point cloud with the

--- a/elevation_mapping/include/elevation_mapping/sensor_processors/SensorProcessorBase.hpp
+++ b/elevation_mapping/include/elevation_mapping/sensor_processors/SensorProcessorBase.hpp
@@ -78,11 +78,19 @@ public:
   virtual bool readParameters();
 
   /*!
-   * Cleans the point cloud.
+   * Cleans the point cloud regardless of the sensor type. Removes NaN, points below the minimal and above
+   * the maximal sensor cutoff value are dropped. Optionally, the
    * @param pointCloud the point cloud to clean.
    * @return true if successful.
    */
-  virtual bool cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
+  bool cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
+
+  /*!
+   * Cleans the point cloud regardless of the sensor type.
+   * @param pointCloud the point cloud to clean.
+   * @return true if successful.
+   */
+   virtual bool cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud) = 0;
 
   /*!
    * Computes the elevation map height variances for each point in a point cloud with the

--- a/elevation_mapping/include/elevation_mapping/sensor_processors/SensorProcessorBase.hpp
+++ b/elevation_mapping/include/elevation_mapping/sensor_processors/SensorProcessorBase.hpp
@@ -78,15 +78,16 @@ public:
   virtual bool readParameters();
 
   /*!
-   * Cleans the point cloud regardless of the sensor type. Removes NaN, points below the minimal and above
-   * the maximal sensor cutoff value are dropped. Optionally, the
+   * Cleans the point cloud regardless of the sensor type. Removes NaN values, points below the minimal and above
+   * the maximal sensor cutoff value are dropped. Optionally, applies voxelGridFilter to reduce number of points in
+   * the point cloud.
    * @param pointCloud the point cloud to clean.
    * @return true if successful.
    */
   bool cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
 
   /*!
-   * Cleans the point cloud regardless of the sensor type.
+   * Sensor specific point cloud cleaning.
    * @param pointCloud the point cloud to clean.
    * @return true if successful.
    */

--- a/elevation_mapping/include/elevation_mapping/sensor_processors/StereoSensorProcessor.hpp
+++ b/elevation_mapping/include/elevation_mapping/sensor_processors/StereoSensorProcessor.hpp
@@ -45,12 +45,11 @@ private:
   bool readParameters();
 
   /*!
-   * Clean the point cloud. Points below the minimal and above the maximal sensor
-   * cutoff value are dropped.
+   * Sensor specific point cloud cleaning.
    * @param pointCloud the point cloud to clean.
    * @return true if successful.
    */
-  virtual bool cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
+  virtual bool cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
 
   /*!
    * Computes the elevation map height variances for each point in a point cloud with the

--- a/elevation_mapping/include/elevation_mapping/sensor_processors/StructuredLightSensorProcessor.hpp
+++ b/elevation_mapping/include/elevation_mapping/sensor_processors/StructuredLightSensorProcessor.hpp
@@ -41,12 +41,11 @@ private:
 	bool readParameters();
 
 	/*!
-	 * Clean the point cloud. Points below the minimal and above the maximal sensor
-	 * cutoff value are dropped.
+	 * Sensor specific point cloud cleaning.
 	 * @param pointCloud the point cloud to clean.
 	 * @return true if successful.
 	 */
-	virtual bool cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
+	virtual bool cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud);
 
   /*!
    * Computes the elevation map height variances for each point in a point cloud with the

--- a/elevation_mapping/src/ElevationMapping.cpp
+++ b/elevation_mapping/src/ElevationMapping.cpp
@@ -77,10 +77,10 @@ ElevationMapping::ElevationMapping(ros::NodeHandle& nodeHandle)
       &fusionServiceQueue_);
   fusionTriggerService_ = nodeHandle_.advertiseService(advertiseServiceOptionsForTriggerFusion);
 
-  AdvertiseServiceOptions advertiseServiceOptionsForGetSubmap = AdvertiseServiceOptions::create<grid_map_msgs::GetGridMap>(
-      "get_submap", boost::bind(&ElevationMapping::getSubmap, this, _1, _2), ros::VoidConstPtr(),
+  AdvertiseServiceOptions advertiseServiceOptionsForGetFusedSubmap = AdvertiseServiceOptions::create<grid_map_msgs::GetGridMap>(
+      "get_submap", boost::bind(&ElevationMapping::getFusedSubmap, this, _1, _2), ros::VoidConstPtr(),
       &fusionServiceQueue_);
-  submapService_ = nodeHandle_.advertiseService(advertiseServiceOptionsForGetSubmap);
+  fusedSubmapService_ = nodeHandle_.advertiseService(advertiseServiceOptionsForGetFusedSubmap);
 
   AdvertiseServiceOptions advertiseServiceOptionsForGetRawSubmap = AdvertiseServiceOptions::create<grid_map_msgs::GetGridMap>(
       "get_raw_submap", boost::bind(&ElevationMapping::getRawSubmap, this, _1, _2), ros::VoidConstPtr(),
@@ -443,7 +443,7 @@ bool ElevationMapping::updateMapLocation()
   return true;
 }
 
-bool ElevationMapping::getSubmap(grid_map_msgs::GetGridMap::Request& request, grid_map_msgs::GetGridMap::Response& response)
+bool ElevationMapping::getFusedSubmap(grid_map_msgs::GetGridMap::Request& request, grid_map_msgs::GetGridMap::Response& response)
 {
   grid_map::Position requestedSubmapPosition(request.position_x, request.position_y);
   Length requestedSubmapLength(request.length_x, request.length_y);

--- a/elevation_mapping/src/sensor_processors/LaserSensorProcessor.cpp
+++ b/elevation_mapping/src/sensor_processors/LaserSensorProcessor.cpp
@@ -45,14 +45,9 @@ bool LaserSensorProcessor::readParameters()
   return true;
 }
 
-bool LaserSensorProcessor::cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud)
+bool LaserSensorProcessor::cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud)
 {
-  pcl::PointCloud<pcl::PointXYZRGB> tempPointCloud;
-  std::vector<int> indices;
-  pcl::removeNaNFromPointCloud(*pointCloud, tempPointCloud, indices);
-  tempPointCloud.is_dense = true;
-  pointCloud->swap(tempPointCloud);
-  ROS_DEBUG("ElevationMap: cleanPointCloud() reduced point cloud to %i points.", static_cast<int>(pointCloud->size()));
+    // Sensor specific cleaning
   return true;
 }
 

--- a/elevation_mapping/src/sensor_processors/PerfectSensorProcessor.cpp
+++ b/elevation_mapping/src/sensor_processors/PerfectSensorProcessor.cpp
@@ -35,19 +35,14 @@ PerfectSensorProcessor::~PerfectSensorProcessor()
 
 bool PerfectSensorProcessor::readParameters()
 {
-  SensorProcessorBase::readParameters();
-  return true;
+    SensorProcessorBase::readParameters();
+    return true;
 }
 
-bool PerfectSensorProcessor::cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud)
+bool PerfectSensorProcessor::cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud)
 {
-  pcl::PointCloud<pcl::PointXYZRGB> tempPointCloud;
-  std::vector<int> indices;
-  pcl::removeNaNFromPointCloud(*pointCloud, tempPointCloud, indices);
-  tempPointCloud.is_dense = true;
-  pointCloud->swap(tempPointCloud);
-  ROS_DEBUG("ElevationMap: cleanPointCloud() reduced point cloud to %i points.", static_cast<int>(pointCloud->size()));
-  return true;
+    // Sensor specific cleaning
+    return true;
 }
 
 bool PerfectSensorProcessor::computeVariances(

--- a/elevation_mapping/src/sensor_processors/SensorProcessorBase.cpp
+++ b/elevation_mapping/src/sensor_processors/SensorProcessorBase.cpp
@@ -72,6 +72,7 @@ bool SensorProcessorBase::process(
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloudSensorFrame(new pcl::PointCloud<pcl::PointXYZRGB>);
   transformPointCloud(pointCloudInput, pointCloudSensorFrame, sensorFrameId_);
   cleanPointCloud(pointCloudSensorFrame);
+  cleanPointCloudSensorType(pointCloudSensorFrame);
 
   if (!transformPointCloud(pointCloudSensorFrame, pointCloudMapFrame, mapFrameId_)) return false;
   std::vector<pcl::PointCloud<pcl::PointXYZRGB>::Ptr> pointClouds({pointCloudMapFrame, pointCloudSensorFrame});

--- a/elevation_mapping/src/sensor_processors/StereoSensorProcessor.cpp
+++ b/elevation_mapping/src/sensor_processors/StereoSensorProcessor.cpp
@@ -34,16 +34,9 @@ bool StereoSensorProcessor::readParameters()
 }
 
 
-bool StereoSensorProcessor::cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud)
+bool StereoSensorProcessor::cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud)
 {
-  pcl::PointCloud<pcl::PointXYZRGB> tempPointCloud;
-
-  originalWidth_ = pointCloud->width;
-  pcl::removeNaNFromPointCloud(*pointCloud, tempPointCloud, indices_);
-  tempPointCloud.is_dense = true;
-  pointCloud->swap(tempPointCloud);
-
-  ROS_DEBUG("ElevationMap: cleanPointCloud() reduced point cloud to %i points.", static_cast<int>(pointCloud->size()));
+  // Sensor specific cleaning
   return true;
 }
 

--- a/elevation_mapping/src/sensor_processors/StructuredLightSensorProcessor.cpp
+++ b/elevation_mapping/src/sensor_processors/StructuredLightSensorProcessor.cpp
@@ -45,10 +45,10 @@ bool StructuredLightSensorProcessor::readParameters()
   return true;
 }
 
-bool StructuredLightSensorProcessor::cleanPointCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud)
+bool StructuredLightSensorProcessor::cleanPointCloudSensorType(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointCloud)
 {
-  SensorProcessorBase::cleanPointCloud(pointCloud);
-	return true;
+    // Sensor specific cleaning
+    return true;
 }
 
 bool StructuredLightSensorProcessor::computeVariances(


### PR DESCRIPTION
This PR updates PR #107 with the necessary changes discussed with @mktk1117 and @remod.

This PR replaces #107 and #98 by incorporating all comments from both PR's.

Important note: The name for the already existing service stays the same, such that it does not break locomotion. The underlying callback functions are named appropriately. 

Summary:
- Service to get raw submap (updated function names as requested in #98).
- Reduction of repeating code in the point cloud clean function.
- Addition of sensor specific clean functions, at the moment empty.
- Addition of voxel grid filter in point cloud clean function with the goal to reduce CPU consumption. 