### PR TITLE
Fixed urdf file not found

### DIFF
--- a/elevation_mapping_demos/launch/turtlesim3_waffle_demo.launch
+++ b/elevation_mapping_demos/launch/turtlesim3_waffle_demo.launch
@@ -19,7 +19,7 @@
   </include>
 
   <!-- Load robot_description param for tf, rviz and gazebo spawn -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find elevation_mapping_demos)models/turtlebot3_description/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find elevation_mapping_demos)/models/turtlebot3_description/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <!-- Spawn turtlebot into gazebo based on robot_description -->
   <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model turtlebot3 -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />


### PR DESCRIPTION
This file was not launching due to an error on line 22, turtlebot3_waffle.urdf.xacro was not found due to a missing "/" in the file path.
Fix tested on Ubuntu 16.04, ROS Kinetic.