### PR TITLE
Add missing pcl_macros import

### DIFF
--- a/elevation_mapping/include/elevation_mapping/PointXYZRGBConfidenceRatio.hpp
+++ b/elevation_mapping/include/elevation_mapping/PointXYZRGBConfidenceRatio.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 


### PR DESCRIPTION
Fixes compile issue which looks like

elevation_mapping/elevation_mapping/include/elevation_mapping/PointXYZRGBConfidenceRatio.hpp:28:3: error: ‘PCL_MAKE_ALIGNED_OPERATOR_NEW’ does not name a type; did you mean ‘EIGEN_MAKE_ALIGNED_OPERATOR_NEW’?
   PCL_MAKE_ALIGNED_OPERATOR_NEW
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

Fixes issue #151