### PR TITLE
Switch header path from hpp to h for filter_chain

### DIFF
--- a/elevation_mapping/include/elevation_mapping/postprocessing/PostprocessingPipelineFunctor.hpp
+++ b/elevation_mapping/include/elevation_mapping/postprocessing/PostprocessingPipelineFunctor.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <ros/ros.h>
-#include <filters/filter_chain.hpp>
+#include <filters/filter_chain.h>
 #include <grid_map_core/GridMap.hpp>
 
 namespace elevation_mapping {


### PR DESCRIPTION
Hi thank you for the work.
This PR changes header path `filter_chain.hpp` to `filter_chain.h` and solves #161.

OS: 18.04.5 LTS (Bionic Beaver)
ROS: melodic