### PR TITLE
changed from python3 to python

### DIFF
--- a/elevation_mapping_demos/scripts/tf_to_pose_publisher.py
+++ b/elevation_mapping_demos/scripts/tf_to_pose_publisher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import rospy
 import geometry_msgs.msg


### PR DESCRIPTION
The standard melodic packages use python 2, so using python 3 here was causing errors when trying to import tf. Compiling tf from source with python 3 worked, but then the other system packages (e.g. gazebo) were crashing because they wanted the python 2 version.