### PR TITLE
Only check for subscribers when using timer to publish elevation map

### DIFF
--- a/elevation_mapping/src/ElevationMapping.cpp
+++ b/elevation_mapping/src/ElevationMapping.cpp
@@ -454,7 +454,7 @@ void ElevationMapping::mapUpdateTimerCallback(const ros::TimerEvent&) {
 }
 
 void ElevationMapping::publishFusedMapCallback(const ros::TimerEvent&) {
-  if (!isFusingEnabled()) {
+  if (!map_.hasFusedMapSubscribers()) {
     return;
   }
   ROS_DEBUG("Elevation map is fused and published from timer.");


### PR DESCRIPTION
`isContinuouslyFusing_` is set to `false` when `fused_map_publishing_rate` is set to a positive non zero value. Checking for `isContinuouslyFusing_` in `publishFusedMapCallback` prevents the elevation map to be published in this case.