### PR TITLE
Add `point_cloud_io` to required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This software is built on the Robotic Operating System ([ROS]), which needs to b
 - [kindr](http://github.com/anybotics/kindr) (kinematics and dynamics library for robotics),
 - [kindr_ros](https://github.com/anybotics/kindr_ros) (ROS wrapper for kindr),
 - [Point Cloud Library (PCL)](http://pointclouds.org/) (point cloud processing),
+- [Point Cloud IO](https://github.com/ANYbotics/point_cloud_io) (IO for point cloud files),
 - [Eigen](http://eigen.tuxfamily.org) (linear algebra library).
 
 


### PR DESCRIPTION
Without `point_cloud_io`, the app cannot read the files with point clouds:
```
ERROR: cannot launch node of type [point_cloud_io/read]: point_cloud_io
ROS path [0]=/opt/ros/noetic/share/ros
ROS path [1]=/root/catkin_ws/src
ROS path [2]=/opt/ros/noetic/share
```